### PR TITLE
Fix tuya magic spell error unexpected keyword argument 'tries'

### DIFF
--- a/custom_components/zha_toolkit/tuya.py
+++ b/custom_components/zha_toolkit/tuya.py
@@ -18,7 +18,7 @@ async def tuya_magic(
     # Magic spell - part 1
     attr_to_read = [4, 0, 1, 5, 7, 0xFFFE]
     res = await u.cluster_read_attributes(
-        basic_cluster, attr_to_read, tries=params[p.TRIES]
+        basic_cluster, attr_to_read#, tries=params[p.TRIES]
     )
 
     event_data["result"] = res


### PR DESCRIPTION
Fix the following error when trying to send tuya magic spell to TS0013:

websocket_api script: Error executing script. Unexpected error for call_service at pos 1: cluster_read_attributes() got an unexpected keyword argument 'tries'

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 468, in _async_step
    await getattr(self, handler)()
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 703, in _async_call_service_step
    response_data = await self._async_run_long_action(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 665, in _async_run_long_action
    return long_task.result()
           ^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 1957, in async_call
    response_data = await coro
                    ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 1997, in _execute_service
    return await cast(
           ^^^^^^^^^^^
  File "/config/custom_components/zha_toolkit/__init__.py", line 778, in toolkit_service
    raise handler_exception
  File "/config/custom_components/zha_toolkit/__init__.py", line 742, in toolkit_service
    await handler(
  File "/config/custom_components/zha_toolkit/__init__.py", line 827, in command_handler_default
    await default.default(
  File "/config/custom_components/zha_toolkit/default.py", line 33, in default
    await handler(app, listener, ieee, cmd, data, service, params, event_data)
  File "/config/custom_components/zha_toolkit/tuya.py", line 20, in tuya_magic
    res = await u.cluster_read_attributes(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/zigpy/util.py", line 153, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
TypeError: cluster_read_attributes() got an unexpected keyword argument 'tries'