### PR TITLE
Fix off by one error calculating the maximum next index in binds_get

### DIFF
--- a/custom_components/zha_toolkit/binds.py
+++ b/custom_components/zha_toolkit/binds.py
@@ -611,7 +611,7 @@ async def binds_get(
                 bindings[next_idx] = bind_info
                 next_idx += 1
 
-            if next_idx + 1 >= total:
+            if next_idx >= total:
                 done = True
                 success = True
             else:


### PR DESCRIPTION
For a device with 16 entries in the binding table and 3 entries per request, the `start_index`es should be 0, 3, 6, 9, 12, 15.

The last `next_idx` will be 15, which is less than the total 16.