### PR TITLE
Fix read_before_write

### DIFF
--- a/custom_components/zha_toolkit/zcl_attr.py
+++ b/custom_components/zha_toolkit/zcl_attr.py
@@ -348,8 +348,7 @@ async def attr_write(  # noqa: C901
     result_read = None
     if (
         params[p.READ_BEFORE_WRITE]
-        or (len(attr_write_list) == 0)
-        or (cmd != S.ATTR_WRITE)
+        or (attr_read_list and cmd == S.ATTR_READ)
     ):
         if use_cache > 0:
             # Try to get value from cache


### PR DESCRIPTION
The previous condition was always true, hence it was not possible to disable read_before_write.