### PR TITLE
fix setting attribute changes state to None

### DIFF
--- a/custom_components/zha_toolkit/utils.py
+++ b/custom_components/zha_toolkit/utils.py
@@ -356,7 +356,11 @@ def set_state(
     #              entity_id, key, value, stateAttrs)
     if key is not None:
         stateAttrs[key] = value
-        value = None
+        if stateObj is not None:
+            # Copy existing state, to update selected item
+            value = stateObj.state
+        else:
+            value = None
 
     # LOGGER.debug("entity:%s key:%s value:%s attrs:%s",
     #              entity_id, key, value, stateAttrs)


### PR DESCRIPTION
Currently, if setting an attribute, the state is set to None which is not desirable.
The fix is to set the new state to be the current state if we are only setting an attribute