### PR TITLE
Fixes for HA 2024.9

### DIFF
--- a/custom_components/zha_toolkit/__init__.py
+++ b/custom_components/zha_toolkit/__init__.py
@@ -806,15 +806,19 @@ async def register_services(hass):  # noqa: C901
                 LOGGER.debug(
                     "Fire %s -> %s", params[p.EVT_SUCCESS], event_data
                 )
-                u.get_hass(zha_gw).bus.fire(params[p.EVT_SUCCESS], event_data)
+                u.get_hass(zha_gw_hass).bus.fire(
+                    params[p.EVT_SUCCESS], event_data
+                )
         else:
             if params[p.EVT_FAIL] is not None:
                 LOGGER.debug("Fire %s -> %s", params[p.EVT_FAIL], event_data)
-                u.get_hass(zha_gw).bus.fire(params[p.EVT_FAIL], event_data)
+                u.get_hass(zha_gw_hass).bus.fire(
+                    params[p.EVT_FAIL], event_data
+                )
 
         if params[p.EVT_DONE] is not None:
             LOGGER.debug("Fire %s -> %s", params[p.EVT_DONE], event_data)
-            u.get_hass(zha_gw).bus.fire(params[p.EVT_DONE], event_data)
+            u.get_hass(zha_gw_hass).bus.fire(params[p.EVT_DONE], event_data)
 
         if handler_exception is not None:
             LOGGER.error(

--- a/custom_components/zha_toolkit/scan_device.py
+++ b/custom_components/zha_toolkit/scan_device.py
@@ -216,7 +216,10 @@ async def discover_attributes_extended(cluster, manufacturer=None, tries=3):
                 attr_name = attr_def.name
             else:
                 attr_name = attr_def[0]
-            attr_type = foundation.DATA_TYPES.get(attr_rec.datatype)
+            try:
+                attr_type = foundation.DataType.from_type_id(attr_rec.datatype)
+            except KeyError:
+                attr_type = None
             access_acl = t.uint8_t(attr_rec.acl)
 
             # Note: reading back Array type was fixed in zigpy 0.58.1 .
@@ -229,8 +232,8 @@ async def discover_attributes_extended(cluster, manufacturer=None, tries=3):
             if attr_type:
                 attr_type = [
                     attr_type_hex,
-                    attr_type[1].__name__,
-                    attr_type[2].__name__,
+                    attr_type.python_type.__name__,
+                    attr_type.type_class.__name__,
                 ]
             else:
                 attr_type = attr_type_hex

--- a/custom_components/zha_toolkit/scan_device.py
+++ b/custom_components/zha_toolkit/scan_device.py
@@ -233,7 +233,7 @@ async def discover_attributes_extended(cluster, manufacturer=None, tries=3):
                 attr_type = [
                     attr_type_hex,
                     attr_type.python_type.__name__,
-                    attr_type.type_class.__name__,
+                    attr_type.type_class.name,
                 ]
             else:
                 attr_type = attr_type_hex

--- a/custom_components/zha_toolkit/utils.py
+++ b/custom_components/zha_toolkit/utils.py
@@ -631,7 +631,7 @@ def record_read_data(
             attr_name = params[p.CSV_LABEL]
         else:
             python_type = type(read_resp[0][attr_id])
-            attr_type = f.DATA_TYPES.pytype_to_datatype_id(python_type)
+            attr_type = f.DataType.from_python_type(python_type).type_id
 
             try:
                 attr_def = cluster.attributes.get(
@@ -690,7 +690,7 @@ def get_attr_type(cluster, attr_id):
         else:
             attr_type = attr_def[1]
 
-        return f.DATA_TYPES.pytype_to_datatype_id(attr_type)
+        return f.DataType.from_python_type(attr_type).type_id
     except Exception:  # nosec
         LOGGER.debug("Could not find type for %s in %r", attr_id, cluster)
 
@@ -800,7 +800,7 @@ def attr_encode(attr_val_in, attr_type):  # noqa C901
     else:
         # Try to apply conversion using foundation DATA_TYPES table
         # Note: this is not perfect and specific conversions may be needed.
-        data_type = f.DATA_TYPES[attr_type][1]
+        data_type = f.DataType.from_type_id(attr_type).python_type
         LOGGER.debug(f"Data type '{data_type}' for attr type {attr_type}")
         if isinstance(attr_val_in, list):
             # Without length byte after serialisation:

--- a/custom_components/zha_toolkit/zcl_attr.py
+++ b/custom_components/zha_toolkit/zcl_attr.py
@@ -382,9 +382,9 @@ async def attr_write(  # noqa: C901
             # Try to get attribute type
             if success and (attr_id in result_read[0]):
                 python_type = type(result_read[0][attr_id])
-                found_attr_type = f.DATA_TYPES.pytype_to_datatype_id(
+                found_attr_type = f.DataType.from_python_type(
                     python_type
-                )
+                ).type_id
                 LOGGER.debug(
                     "Type determined from read: 0x%02x", found_attr_type
                 )

--- a/hacs.json
+++ b/hacs.json
@@ -5,5 +5,5 @@
   "filename": "zha-toolkit.zip",
   "render_readme": true,
   "persistent_directory": "local",
-  "homeassistant": "2024.8.0"
+  "homeassistant": "2024.9.0"
 }


### PR DESCRIPTION
The PR adds fixes to get this custom component working with Home Assistant 2024.9 (tested with 2024.91. and 2024.9.2)
Specifically it fixes issues #258 and #261 and bumps the required version.