### PR TITLE
Add Scenes and Window Coverings as bindable clusters

### DIFF
--- a/custom_components/zha_toolkit/binds.py
+++ b/custom_components/zha_toolkit/binds.py
@@ -12,8 +12,10 @@ from .params import INTERNAL_PARAMS as p
 LOGGER = logging.getLogger(__name__)
 
 BINDABLE_OUT_CLUSTERS = [
+    0x0005,  # Scenes
     0x0006,  # OnOff
     0x0008,  # Level
+    0x0102,  # Window Covering
     0x0300,  # Color Control
 ]
 BINDABLE_IN_CLUSTERS = [


### PR DESCRIPTION
For Somfy Zigbee window coverings, remotes are paired with window coverings by binding the Window Coverings (0x0102) and Scenes (0x0005) clusters. Window Coverings handles open/close/stop commands, whereas the Scenes cluster handles save/recall of presets.