### PR TITLE
Fix `zcl_cmd`

### DIFF
--- a/custom_components/zha_toolkit/zcl_cmd.py
+++ b/custom_components/zha_toolkit/zcl_cmd.py
@@ -98,11 +98,21 @@ async def zcl_cmd(app, listener, ieee, cmd, data, service, params, event_data):
                     False,
                 )
             elif cmd_id not in cluster.server_commands:
-                cmd_schema: list[Any] = []
+                schema_dict: dict[str, Any] = {}
 
                 if cmd_args is not None:
-                    cmd_schema = [t.uint8_t] * len(cmd_args)
+                    schema_dict = {
+                        f"param{i + 1}": t.uint8_t
+                        for i in range(len(cmd_args))
+                    }
 
+                temp = foundation.ZCLCommandDef(
+                    schema=schema_dict,
+                    direction=foundation.Direction.Client_to_Server,
+                    id=cmd_id,
+                    name="schema",
+                )
+                cmd_schema = temp.with_compiled_schema().schema
                 cmd_def = foundation.ZCLCommandDef(
                     name=f"zha_toolkit_dummy_cmd{cmd_id}",
                     id=cmd_id,


### PR DESCRIPTION
This resolves #282.

In [this change](https://github.com/zigpy/zigpy/commit/c63706107d536b4280f2526224f8c5b16a76e242#diff-fa4cb1cc913a5e9930eabf531f3236c62e6ebcf2b9bcf66273b74d28c7c91cddL312-L319), the conversion of schemas on any `ZCLCommandDef` objects from lists to struct based schemas was removed. This feature appears to have been deprecated at some point in the past as the commit message alludes to the fact that these were only valid for unit tests. The original conversion from a list to a compiled schema appears to have been done in zigpy/zigpy@5690a1192738e547b1f18bf30cdbd94d0eb32ff2 in April of 2021. I'm not sure how far back you're supporting things, but this is quite a while ago.
