### PR TITLE
:recycle: Update trigger syntax in blueprints

### DIFF
--- a/blueprints/backup.yaml
+++ b/blueprints/backup.yaml
@@ -12,8 +12,8 @@ blueprint:
         Time at which the daily backup should be made.
       selector:
         time:
-trigger:
-  - platform: time
+triggers:
+  - trigger: time
     at: !input backup_time
 condition: []
 action:

--- a/blueprints/backup_znp.yaml
+++ b/blueprints/backup_znp.yaml
@@ -10,8 +10,8 @@ blueprint:
         Time at which the daily backup should be madeaction should start
       selector:
         time:
-trigger:
-  - platform: time
+triggers:
+  - trigger: time
     at: !input backup_time
 condition: []
 action:

--- a/blueprints/danfoss_ally_remote_temperature.yaml
+++ b/blueprints/danfoss_ally_remote_temperature.yaml
@@ -67,11 +67,11 @@ variables:
   min_update_minutes: !input min_update_minutes
   temp_sensor_id: !input temp_sensor_id
   temp_offset: !input temperature_offset
-trigger:
-  - platform: state
+triggers:
+  - trigger: state
     entity_id:
       - !input temp_sensor_id
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 condition:
   - condition: template

--- a/blueprints/danfoss_ally_remote_temperature_min_delay.yaml
+++ b/blueprints/danfoss_ally_remote_temperature_min_delay.yaml
@@ -53,11 +53,11 @@ variables:
   temp_sensor_id: !input temp_sensor_id
   temp_offset: !input temperature_offset
   temperature: "{{ states(temp_sensor_id) }}"
-trigger:
-  - platform: state
+triggers:
+  - triggers: state
     entity_id:
       - !input temp_sensor_id
-  - platform: event
+  - triggers: event
     event_type: homeassistant_start
     id: ha_restart
 condition:

--- a/examples/script_request_all_light_states.yaml
+++ b/examples/script_request_all_light_states.yaml
@@ -9,7 +9,7 @@ description: >-
   You can call this script in an automation triggered by the group action, or on a
   timely basis.
   (Original script by @HarvsG in https://github.com/mdeweerd/zha-toolkit/issues/113#issuecomment-1335616201)
-trigger: []
+triggers: []
 condition: []
 action:
   - repeat:

--- a/examples/script_use_zha_devices.yaml
+++ b/examples/script_use_zha_devices.yaml
@@ -4,7 +4,7 @@ sequence:
   - parallel:
       - sequence:
           - wait_for_trigger:
-              - platform: event
+              - trigger: event
                 event_type: zha_devices_ready
           - service: system_log.write
             data:


### PR DESCRIPTION
Changed trigger syntax from:
  - 'platform:' to 'trigger:'
  - trigger:  to 'triggers:'