### PR TITLE
Fix rejoin(): EUI64.convert_ieee does not exist, use get_ieee() helper

### DIFF
--- a/custom_components/zha_toolkit/misc.py
+++ b/custom_components/zha_toolkit/misc.py
@@ -141,7 +141,7 @@ async def rejoin(app, listener, ieee, cmd, data, service, params, event_data):
     if data is None:
         await app.permit()
     else:
-        await app.permit(node=t.EUI64.convert_ieee(data))
+        await app.permit(node=await u.get_ieee(app, listener, data))
 
     method = 1
     res = None


### PR DESCRIPTION
## Summary
`t.EUI64.convert_ieee()` is called in `misc.py::rejoin()` but has never existed as a method on zigpy's `EUI64` class. It appears to be confused with a same-named free function in `zigpy/appdb.py` that internally just calls `EUI64.convert(str)` on a raw string. As a result, `rejoin()` always raises `AttributeError` whenever `command_data` (the router to scope the rejoin through) is supplied.

There's a second, related issue: the Voluptuous service schema for `REJOIN` already converts `command_data` to an `EUI64` instance before `rejoin()` runs, so calling `.convert()` again would fail on non-string input anyway (`'EUI64' object has no attribute 'replace'`), even after fixing the method name.

## Fix
Use the existing `utils.get_ieee(app, listener, ref)` helper, which already has correct passthrough logic for both `EUI64` instances and raw strings/entity IDs/UUIDs — consistent with how every other command handler in this project resolves IEEE addresses.

```diff
-        await app.permit(node=t.EUI64.convert_ieee(data))
+        await app.permit(node=await u.get_ieee(app, listener, data))
```

## Test plan
- [x] `python -m py_compile` on the changed file
- [x] Verified locally against zigpy 1.5.1 with two real `zha_toolkit.rejoin` service calls: one with `command_data` as an entity_id, one with `command_data` as a raw IEEE hex string — both succeeded (previously both raised `AttributeError`, just with different messages depending on input type)
- [x] Checked HA log for the full test window: 0 occurrences of `convert_ieee` or `'EUI64' object has no attribute 'replace'` afterwards
- [x] Searched the whole repo for other `convert_ieee` occurrences — none found besides this one

🤖 Generated with [Claude Code](https://claude.com/claude-code)