### PR TITLE
 fix: honor endpoint/cluster in unbind_group and use app.state.node_info.ieee

### DIFF
--- a/custom_components/zha_toolkit/binds.py
+++ b/custom_components/zha_toolkit/binds.py
@@ -251,7 +251,7 @@ async def bind_ieee(
     src_dev = await u.get_device(app, listener, ieee)
     if data in [0, False, "0", None]:
         # when command_data is set to 0 or false, bind to coordinator
-        data = app.state.node_info.ieee
+        data = u.get_coordinator_ieee(app)
 
     dst_dev = await u.get_device(app, listener, data)
 
@@ -433,7 +433,7 @@ async def unbind_coordinator(
     app, listener, ieee, cmd, data, service, params, event_data
 ):
     # Unbind bindings towards the coordinator:
-    data = app.state.node_info.ieee
+    data = u.get_coordinator_ieee(app)
 
     # Use binds_remove_all with parameters
     await binds_remove_all(

--- a/custom_components/zha_toolkit/binds.py
+++ b/custom_components/zha_toolkit/binds.py
@@ -251,7 +251,7 @@ async def bind_ieee(
     src_dev = await u.get_device(app, listener, ieee)
     if data in [0, False, "0", None]:
         # when command_data is set to 0 or false, bind to coordinator
-        data = app.ieee
+        data = app.state.node_info.ieee
 
     dst_dev = await u.get_device(app, listener, data)
 
@@ -433,7 +433,7 @@ async def unbind_coordinator(
     app, listener, ieee, cmd, data, service, params, event_data
 ):
     # Unbind bindings towards the coordinator:
-    data = app.ieee
+    data = app.state.node_info.ieee
 
     # Use binds_remove_all with parameters
     await binds_remove_all(

--- a/custom_components/zha_toolkit/binds.py
+++ b/custom_components/zha_toolkit/binds.py
@@ -186,10 +186,19 @@ async def unbind_group(
     dst_addr = MultiAddress()
     dst_addr.addrmode = t.uint8_t(1)
     dst_addr.nwk = t.uint16_t(group_id)
+    u_epid = params[p.EP_ID]
+    u_cluster_id = params[p.CLUSTER_ID]
+
+    if u_cluster_id is not None:
+        src_out_cls = [u_cluster_id]
+
     results: dict[int, list[dict[str, int]]] = {}
     for src_out_cluster in src_out_cls:
         src_ep = None
         for ep_id, ep in src_dev.endpoints.items():
+            if u_epid is not None and ep_id != u_epid:
+                # Endpoint not selected
+                continue
             if ep_id == 0:
                 continue
             if src_out_cluster in ep.out_clusters:

--- a/custom_components/zha_toolkit/utils.py
+++ b/custom_components/zha_toolkit/utils.py
@@ -429,6 +429,19 @@ async def get_device(app, listener, reference):
     return app.get_device(ieee)
 
 
+def get_coordinator_ieee(app):
+    """Return the coordinator's IEEE address.
+
+    Recent zigpy releases dropped the ``ControllerApplication.ieee``
+    shortcut in favour of ``app.state.node_info.ieee``. Prefer the new
+    location and fall back to the legacy attribute for older zigpy.
+    """
+    try:
+        return app.state.node_info.ieee
+    except AttributeError:
+        return app.ieee
+
+
 # Save state to db
 def set_state(
     hass, entity_id, value, key=None, allow_create=False, force_update=False

--- a/custom_components/zha_toolkit/zdo.py
+++ b/custom_components/zha_toolkit/zdo.py
@@ -153,7 +153,7 @@ async def zdo_flood_parent_annce(
 
 
 async def _flood_with_parent_annce(app, listener):
-    coord = await u.get_device(app, listener, app.ieee)
+    coord = await u.get_device(app, listener, app.state.node_info.ieee)
 
     while True:
         children = [

--- a/custom_components/zha_toolkit/zdo.py
+++ b/custom_components/zha_toolkit/zdo.py
@@ -153,7 +153,7 @@ async def zdo_flood_parent_annce(
 
 
 async def _flood_with_parent_annce(app, listener):
-    coord = await u.get_device(app, listener, app.state.node_info.ieee)
+    coord = await u.get_device(app, listener, u.get_coordinator_ieee(app))
 
     while True:
         children = [


### PR DESCRIPTION
Two independent bug fixes in the binding code, both found while binding a multi-endpoint ZLL controller (a 4-gang Busch-Jaeger wall transmitter, model RB01, whose four rocker rows are endpoints 0x0a–0x0d and all expose the same OnOff/Level/Scenes output clusters) to the coordinator via zha_toolkit.execute.

1. unbind_group ignored the endpoint and cluster parameters

unbind_group iterated over all BINDABLE_OUT_CLUSTERS and, for each cluster, picked the first endpoint exposing it — it never looked at the endpoint or cluster parameters. On a device that exposes the same output clusters on several endpoints, every call therefore acted on the first matching endpoint only, so group binds on the other endpoints could never be removed (each unbind_group with endpoint: 11/12/13 kept operating on 0x0a).

bind_group already filters by u_epid / u_cluster_id; this applies the same filtering to unbind_group so the two commands are symmetric and the requested endpoint/cluster is actually targeted.

2. app.ieee → app.state.node_info.ieee

zigpy's ControllerApplication no longer exposes an ieee attribute, so bind_ieee (bind-to-coordinator), unbind_coordinator and zdo_flood_parent_annce raised:

'ControllerApplication' object has no attribute 'ieee'

Switched the three call sites to the canonical app.state.node_info.ieee. I think this fixes #326 as well.

Scope / compatibility

- unbind_group is only reachable via zha_toolkit.execute (it is not a registered service in services.yaml), so no schema/services.yaml/__init__.py changes are needed — execute already passes endpoint and cluster through, and they default to None when omitted (unchanged behaviour for existing callers).
- No public API or command signatures change.

Testing

Verified live against a Sonoff ZBDongle-E (EZSP) coordinator:

- Before: binds_get on the RB01 showed ep0b/0c/0d → group 0x0005 (Scenot remove.
- After patch 1: unbind_group with endpoint: 11 (then 12, 13) removed exactly the requested endpoint's group bind.
- After patch 2: bind_ieee (bind-to-coordinator) and unbind_coordinatoror.
- End result: all four endpoints show cluster 0x0006 → coordinator and every rocker row now emits zha_events.