### PR TITLE
feat: add misc_reinterview, the service equivalent of ZHA "Reconfigure"

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ ZHA Toolkit can also:
   - [Join & Network presence related](#join--network-presence-related)
     - [`handle_join`: Handle join - rediscover device](#handle_join-handle-join---rediscover-device)
     - [`misc_reinitialize`: Reinitialize device](#misc_reinitialize-reinitialize-device)
+    - [`misc_reinterview`: Re-interview device (ZHA "Reconfigure")](#misc_reinterview-re-interview-device-zha-reconfigure)
     - [`leave`](#leave)
     - [`rejoin`](#rejoin)
     - [`zdo_join_with_code`](#zdo_join_with_code)
@@ -1224,6 +1225,51 @@ data:
   # Reference of the device that should be reinitialized
   ieee: 00:12:4b:00:22:08:ed:1a
 ```
+
+### `misc_reinterview`: Re-interview device (ZHA "Reconfigure")
+
+`misc_reinterview` is the service equivalent of the **Reconfigure** button
+on the ZHA device page. Zigpy rediscovers the device's endpoints, clusters
+and model info, then swaps the device in place. ZHA reacts to the
+`device_reinterviewed` event zigpy emits and re-establishes the bindings
+and attribute reporting, exactly as it does for the button.
+
+Use it when a device still reports (so ZHA shows it as available, with a
+fresh `last_seen` and a ticking LQI) but no longer accepts commands, which
+is a state where the inbound path works while the outbound one is broken.
+
+Compared to the neighbouring commands:
+
+- `handle_join` does almost nothing on an already-initialized device.
+- `misc_reinitialize` clears device attributes in place to force
+  re-initialization, so a failed rediscovery leaves the device stripped.
+  `misc_reinterview` discovers into a shadow device and only replaces the
+  existing one **once discovery has succeeded**, keeping the old device on
+  failure.
+- `rejoin` makes the device leave and rejoin. `misc_reinterview` never asks
+  the device to leave, so its NWK, its entity ids and everything
+  referencing them survive.
+
+```yaml
+action: zha_toolkit.misc_reinterview
+data:
+  # Reference of the device that should be re-interviewed
+  ieee: 00:12:4b:00:22:08:ed:1a
+```
+
+Zigpy does not raise when a re-interview fails: it logs a warning and emits
+`device_reinterview_failure`. It also returns early when a re-interview or
+an initialization is already running, or while an OTA is in progress. So
+this command reports whether the device was actually replaced in
+`event_data`:
+
+```yaml
+result: true   # the device was re-interviewed and swapped
+result: false  # nothing changed, see the log for the reason
+```
+
+Requires a zigpy version providing `Device.reinterview()`; the command
+fails with a clear error on older versions.
 
 ### `leave`
 

--- a/custom_components/zha_toolkit/__init__.py
+++ b/custom_components/zha_toolkit/__init__.py
@@ -20,6 +20,8 @@ from . import params as PARDEFS
 from . import utils as u
 from .const import DOMAIN
 
+# pylint: disable=too-many-lines
+
 DEPENDENCIES = ["zha"]
 
 # Legacy parameters
@@ -393,6 +395,14 @@ SERVICE_SCHEMAS = {
         extra=vol.ALLOW_EXTRA,
     ),
     S.MISC_REINITIALIZE: vol.Schema(
+        {
+            vol.Required(ATTR_IEEE): vol.Any(
+                cv.entity_id_or_uuid, t.EUI64.convert
+            ),
+        },
+        extra=vol.ALLOW_EXTRA,
+    ),
+    S.MISC_REINTERVIEW: vol.Schema(
         {
             vol.Required(ATTR_IEEE): vol.Any(
                 cv.entity_id_or_uuid, t.EUI64.convert

--- a/custom_components/zha_toolkit/misc.py
+++ b/custom_components/zha_toolkit/misc.py
@@ -204,6 +204,49 @@ async def rejoin(app, listener, ieee, cmd, data, service, params, event_data):
     LOGGER.debug("%s -> %s: leave and rejoin result: %s", src, ieee, res)
 
 
+async def misc_reinterview(
+    app, listener, ieee, cmd, data, service, params, event_data
+):
+    """Re-interview a device without removing it from the network.
+
+    This is the equivalent of the "Reconfigure" button on the ZHA device
+    page: zigpy rediscovers the endpoints, clusters and model info, then
+    swaps the device in place.  Bindings and attribute reporting are
+    re-established by ZHA, which reacts to the `device_reinterviewed`
+    event zigpy emits on success.
+
+    Unlike `rejoin`, the device is never asked to leave, so its NWK, its
+    entity ids and everything referencing them survive.  Unlike
+    `misc_reinitialize`, the existing device is only replaced once
+    rediscovery has succeeded: zigpy discovers into a shadow device and
+    keeps the old one on failure.
+
+    ieee -- ieee of the device
+    """
+    if ieee is None:
+        msg = f"Provide 'ieee' parameter for {cmd}"
+        LOGGER.debug(msg)
+        raise ValueError(msg)
+
+    dev = await u.get_device(app, listener, ieee)
+
+    if not hasattr(dev, "reinterview"):
+        raise ValueError(
+            "Device.reinterview() is not available, zigpy is too old"
+        )
+
+    # `reinterview()` does not raise on failure: it logs, emits
+    # `device_reinterview_failure` and returns.  It also returns early
+    # when a re-interview or an initialization is already running, or
+    # while an OTA is in progress.  In every one of those cases the
+    # device object is left in place, so comparing identity afterwards is
+    # what tells us whether the swap actually happened.  This is the same
+    # check ZHA itself uses after calling `async_reinterview_device`.
+    await dev.reinterview()
+
+    event_data["result"] = app.devices.get(dev.ieee) is not dev
+
+
 async def misc_settime(
     app, listener, ieee, cmd, data, service, params, event_data
 ):

--- a/custom_components/zha_toolkit/params.py
+++ b/custom_components/zha_toolkit/params.py
@@ -79,6 +79,7 @@ class SERVICE_consts:  # pylint: disable=too-few-public-methods
     IEEE_PING = "ieee_ping"
     LEAVE = "leave"
     MISC_REINITIALIZE = "misc_reinitialize"
+    MISC_REINTERVIEW = "misc_reinterview"
     MISC_SETTIME = "misc_settime"
     OTA_NOTIFY = "ota_notify"
     REJOIN = "rejoin"

--- a/custom_components/zha_toolkit/services.yaml
+++ b/custom_components/zha_toolkit/services.yaml
@@ -1806,6 +1806,27 @@ misc_reinitialize:
       selector:
         entity:
           integration: zha
+misc_reinterview:
+  name: Reinterview Device
+  description: >-
+    Re-interview a device without removing it from the network, the
+    equivalent of the "Reconfigure" button on the ZHA device page. Zigpy
+    rediscovers the endpoints, clusters and model info, then swaps the
+    device in place, and ZHA re-establishes bindings and attribute
+    reporting. The device keeps its NWK and its entity ids. On failure the
+    existing device is kept, and the result field reports whether the
+    device was actually replaced.
+  fields:
+    ieee:
+      name: Device Reference
+      description: >-
+        Entity name, device name, or IEEE address of the node to execute
+        command
+      example: 00:0d:6f:00:05:7d:2d:34
+      required: true
+      selector:
+        entity:
+          integration: zha
 misc_settime:
   name: Set Time
   description: Set Time Cluster attributes (Time, DST - except TimeStatus)

--- a/custom_components/zha_toolkit/translations/en.json
+++ b/custom_components/zha_toolkit/translations/en.json
@@ -1034,6 +1034,16 @@
         }
       }
     },
+    "misc_reinterview": {
+      "name": "Reinterview Device",
+      "description": "Re-interview a device without removing it from the network, the equivalent of the Reconfigure button on the ZHA device page",
+      "fields": {
+        "ieee": {
+          "name": "Device Reference",
+          "description": "Entity name, device name, or IEEE address of the node to execute command"
+        }
+      }
+    },
     "misc_settime": {
       "name": "Set Time",
       "description": "Set Time Cluster attributes (Time, DST - except TimeStatus)",

--- a/custom_components/zha_toolkit/translations/zh-Hans.json
+++ b/custom_components/zha_toolkit/translations/zh-Hans.json
@@ -1034,6 +1034,16 @@
         }
       }
     },
+    "misc_reinterview": {
+      "name": "重新采访设备",
+      "description": "相当于 ZHA 设备页面上的重新配置按钮，在不将设备从网络中移除的情况下重新采访设备",
+      "fields": {
+        "ieee": {
+          "name": "设备引用",
+          "description": "要执行命令的节点的实体名称、设备名称或 IEEE 地址"
+        }
+      }
+    },
     "misc_settime": {
       "name": "设置时间",
       "description": "设置时间集群属性（时间、夏令时 - TimeStatus 除外）",


### PR DESCRIPTION
## What

Adds `misc_reinterview`, the service equivalent of the **Reconfigure** button on the ZHA device page.

ZHA only exposes reconfigure as the WebSocket command `zha/devices/reconfigure`, so it cannot be called from an automation or a script. This reaches the same behaviour through zigpy directly.

```yaml
action: zha_toolkit.misc_reinterview
data:
  ieee: 00:12:4b:00:22:08:ed:1a
```

## Why

I have a TS011F plug that periodically stops accepting commands while ZHA still reports it perfectly healthy: `available: true`, fresh `last_seen`, LQI ticking, zero entities unavailable, but every command returns `<Status.MAC_NO_ACK: 233>`. It has done this five times in three weeks.

The remedies I had were all manual: press the button on the plug, wait it out (once took 17.5 h), or re-pair it. An HA restart never helps. The one thing that reliably fixes it in seconds is the Reconfigure button, and that is exactly the thing I could not automate.

## How it works

The handler calls zigpy's `Device.reinterview()`. Zigpy rediscovers the endpoints, clusters and model info, swaps the device in place, and emits `device_reinterviewed` on the application. ZHA subscribes to that event and rebuilds the device, re-establishing bindings and attribute reporting.

So the outcome matches the UI button without importing anything from ZHA. Confirmed in the log during testing:

```
zha_toolkit  Running ZHA Toolkit service: misc_reinterview ieee=a4:c1:...
zha.application.gateway  Rebuilding device 0xE30F:a4:c1:... after reinterview
```

## How it differs from the neighbouring commands

- `handle_join` does almost nothing on an already-initialized device. Its own comment says so: *"Handle join will initialize the device if it isn't yet, otherwise only scan groups"*. This fault always involves an initialized device.
- `misc_reinitialize` clears device attributes in place to force re-initialization, so a failed rediscovery leaves the device stripped. `Device.reinterview()` discovers into a shadow device and replaces the existing one only once discovery has succeeded, keeping the old device and its DB state on failure. That matters here, because the device is by definition unreachable when you reach for this.
- `rejoin` makes the device leave and rejoin. `misc_reinterview` never asks it to leave, so the NWK and the entity ids survive.

## Reporting the result

`reinterview()` does not raise when it fails: it logs, emits `device_reinterview_failure` and returns. It also returns early when a re-interview or an initialization is already running, or during an OTA. In all of those cases the device object stays in place, so the handler reports success by checking whether the device was actually swapped:

```python
event_data["result"] = app.devices.get(dev.ieee) is not dev
```

That is the same check ZHA makes after calling `async_reinterview_device`. `result: false` means nothing changed, and the log says why.

## Testing

Tested on a live network with 132 devices, zigpy 2.1.0, zha 2.1.0.

**On a healthy mains router**, to check it is not disruptive: `result: true`, entity count, states, availability and mesh counters all unchanged, `device_id` unchanged, total elapsed about 1 second.

**On the actual fault**, which is the case it exists for:

| | before | after |
|---|---|---|
| commands | `MAC_NO_ACK: 233` | succeed |
| `ieee_ping` | not attempted | status 0 |
| LQI | 87 | 116 |
| voltage | 226.9, stale | 228.8, reporting live |
| freshest report | 6.6 min ago | 0.0 min ago |
| NWK / `device_id` | | unchanged |

One call, roughly a second, and the `switch.turn_on` that had failed moments earlier went through.

I have since wired it into the automation that manages that plug: retry, then re-interview once behind an hourly cooldown, then retry, then raise a repair. It replaces a retry ladder that was burning about 14 minutes of exponential backoff every 15 minutes against a device that would never answer.

## Notes for review

- **Compatibility, and why the guard is not theoretical**: `Device.reinterview()` is recent. It landed in zigpy/zigpy#1789 on 2026-04-29 and first shipped in **zigpy 1.4.0**. This repo's mypy hook still pins **zigpy==0.61.0**, which does not have the method at all, so on an older zigpy the handler would hit an `AttributeError`. It checks with `hasattr` and raises a clear error instead. Happy to switch to an explicit version check, or to gate it behind a minimum zigpy in the manifest, whichever you prefer.
- **`# pylint: disable=too-many-lines` in `__init__.py`**: the new schema pushes the module from 996 to 1004 lines, past pylint's default 1000. I matched the existing disable at the top of `utils.py` rather than touching `setup.cfg`. Say if you would rather bump `max-module-lines` or split the module.
- **`__init__.py` is the only CRLF file in the repo**, so I kept its line endings. Worth knowing if a contributor's editor ever silently converts it, since that produces a whole-file diff.
- I could not get `register_services` alone to pick the new service up: `reload_services_yaml` re-reads `services.yaml`, but the service itself is registered from `SERVICE_SCHEMAS` in the already-loaded `__init__.py`, so `async_set_service_schema` raises `KeyError` for a service that was never registered. A restart works. Contributing.md suggests `register_services` is enough, so either I am missing a step or that note could use a caveat.
- Docs added to README with a TOC entry, alongside `misc_reinitialize`.
