### PR TITLE
ci: update workflow actions to current majors

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,14 +12,14 @@ jobs:
     steps:
       - run: sudo apt-get update && sudo apt-get install cppcheck
         if: false
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         if: false
         with:
           cache: pip
           python-version: 3.12.1
       - run: python -m pip install pre-commit
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v6
         with:
           path: ~/.cache/pre-commit/
           key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
@@ -36,13 +36,13 @@ jobs:
         with:
           in: ${{ env.RAW_LOG }}
           # out: ${{ env.CS_XML }}
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v6
         if: ${{ ! cancelled() }}
         with:
           path: ~/.cache/pre-commit/
           key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Provide log as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ ! cancelled() }}
         with:
           name: precommit-logs

--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -11,7 +11,7 @@ jobs:
         #run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
         id: extract_branch
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ steps.extract_branch.outputs.branch }}
       - run: ${{ github.workspace }}/.github/scripts/gen_stats.sh

--- a/.github/workflows/validate-hacs.yml
+++ b/.github/workflows/validate-hacs.yml
@@ -11,13 +11,13 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: home-assistant/actions/hassfest@master
   hacs:
     name: HACS Action
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: HACS Action
         uses: hacs/action@main
         with:


### PR DESCRIPTION
Updates GitHub-maintained actions to current majors in the non-release workflows.

Changes:
- actions/checkout v6 to v7 in pre-commit, validate-hacs, codeql-analysis, and stats workflows
- actions/setup-python v5 to v7 in pre-commit
- actions/cache/restore and cache/save v4 to v6 in pre-commit
- actions/upload-artifact v4 to v7 in pre-commit

Notes on compatibility:
- checkout v7 blocks fork PR checkout under pull_request_target and workflow_run triggers; none of these workflows use them
- setup-python v7 removed the pip-install input; this workflow does not use it
- setup-python step here runs only when manually enabled (has an if: false condition) and still parses under v7

Validation:
- YAML parse check passes for all changed workflows

Scope: .github/workflows only. release.yml and release-drafter.yml left unchanged.